### PR TITLE
Make GPS formatting renderable on devices w/ a limited font

### DIFF
--- a/main/vendor/GPS/gps_logger.c
+++ b/main/vendor/GPS/gps_logger.c
@@ -328,8 +328,8 @@ static void format_coordinates(double lat, double lon, char *lat_str, char *lon_
     int lon_deg = (int)fabs(lon);
     double lon_min = (fabs(lon) - lon_deg) * 60;
 
-    sprintf(lat_str, "%d°%.4f'%c", lat_deg, lat_min, lat >= 0 ? 'N' : 'S');
-    sprintf(lon_str, "%d°%.4f'%c", lon_deg, lon_min, lon >= 0 ? 'E' : 'W');
+    sprintf(lat_str, "%ddeg %.4f'%c", lat_deg, lat_min, lat >= 0 ? 'N' : 'S');
+    sprintf(lon_str, "%ddeg %.4f'%c", lon_deg, lon_min, lon >= 0 ? 'E' : 'W');
 }
 
 float get_accuracy_percentage(float hdop) {


### PR DESCRIPTION
Turns out the flippers font library cannot render the degree symbol. Changed the formatting to use "deg" to denote degrees in gps coordinates instead of the symbol.

I guess the other option is to write a parser and interface for the flipper app :thinking: 