### PR TITLE
Hide Touch Nav on non-touch devices

### DIFF
--- a/main/managers/views/options_screen.c
+++ b/main/managers/views/options_screen.c
@@ -162,9 +162,12 @@ void options_menu_create() {
 
     // Calculate heights considering status bar (20px) and scroll buttons
     const int STATUS_BAR_HEIGHT = 20;
-    const int BUTTON_AREA_HEIGHT = SCROLL_BTN_SIZE + SCROLL_BTN_PADDING * 2;
+#ifdef CONFIG_USE_TOUCHSCREEN
+    const int BUTTON_AREA_HEIGHT = SCROLL_BTN_SIZE + SCROLL_BTN_PADDING * 2; // set size of touch navigation buttons
     int container_height = screen_height - STATUS_BAR_HEIGHT - BUTTON_AREA_HEIGHT;
-
+#else
+    int container_height = screen_height - STATUS_BAR_HEIGHT;
+#endif
     menu_container = lv_list_create(root);
     lv_obj_set_style_radius(menu_container, 0, LV_PART_MAIN);
     // Adjust size and position
@@ -212,7 +215,7 @@ void options_menu_create() {
 
     select_option_item(0);
     display_manager_add_status_bar(options_menu_type_to_string(SelectedMenuType));
-
+#ifdef CONFIG_USE_TOUCHSCREEN // only show touch buttons if on a touch screen device.
     // Create scroll buttons and back button
     scroll_up_btn = lv_btn_create(root); // UP button on the LEFT
     lv_obj_set_size(scroll_up_btn, SCROLL_BTN_SIZE, SCROLL_BTN_SIZE);
@@ -251,7 +254,7 @@ void options_menu_create() {
     lv_obj_t *back_label = lv_label_create(back_btn);
     lv_label_set_text(back_label, LV_SYMBOL_LEFT " Back"); // Back symbol and text
     lv_obj_center(back_label);
-
+#endif
     createdTimeInMs = (unsigned long)(esp_timer_get_time() / 1000ULL);
 }
 

--- a/main/managers/views/options_screen.c
+++ b/main/managers/views/options_screen.c
@@ -261,8 +261,8 @@ void options_menu_create() {
 static void select_option_item(int index) {
     printf("select_option_item called with index: %d, num_items: %d\n", index, num_items);
 
-    if (index < 0) index = 0;
-    if (index >= num_items) index = num_items - 1;
+    if (index < 0) index = num_items - 1; // if we hit the top of the menu wrap to the bottom
+    if (index >= num_items) index = 0; // if we hit the bottom of the menu wrap to the top
 
     printf("Adjusted index: %d\n", index);
 


### PR DESCRIPTION
This accomplishes 2 changes

1. Hide Touch Nav on non-touch devices
2. Enable wrapping when the user hits the bottom of the options list