### PR TITLE
Fixed sd card init on esp32 generics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,8 @@
 - Cardputer
   - Get cardputer battery status working - @tototo31
 
-
+- General
+ - Fix SD Card init on CYD devices - @tototo31
 
 
 ## Revival v1.5.1

--- a/main/managers/sd_card_manager.c
+++ b/main/managers/sd_card_manager.c
@@ -312,7 +312,7 @@ esp_err_t sd_card_init(void) {
 
 #if defined(CONFIG_IDF_TARGET_ESP32)
   {
-    esp_err_t bus_ret = spi_bus_initialize(SPI2_HOST, &bus_config, dmabus);
+    esp_err_t bus_ret = spi_bus_initialize(SPI3_HOST, &bus_config, dmabus);
     if (bus_ret == ESP_OK) {
       bus_init_success = true;
     } else if (bus_ret != ESP_ERR_INVALID_STATE) {
@@ -350,7 +350,7 @@ esp_err_t sd_card_init(void) {
   sdspi_device_config_t slot_config = SDSPI_DEVICE_CONFIG_DEFAULT();
   slot_config.gpio_cs = sd_card_manager.spi_cs_pin;
 #if defined(CONFIG_IDF_TARGET_ESP32)
-  slot_config.host_id = SPI2_HOST;
+  slot_config.host_id = SPI3_HOST;
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)
   slot_config.host_id = SPI2_HOST;
 #else


### PR DESCRIPTION
THis also fixes the issue on phantoms


IDK why this got changed at some point, but this is how things werre setup in tag v1.4.9 and sd card worked then. Changed it back and its working again