### PR TITLE
fix: update IDF_TARGET check to include esp32c3 for M5GFX exclusion

### DIFF
--- a/components/M5GFX/CMakeLists.txt
+++ b/components/M5GFX/CMakeLists.txt
@@ -1,4 +1,4 @@
-if("${IDF_TARGET}" STREQUAL "esp32c5" OR "${IDF_TARGET}" STREQUAL "esp32c6" OR "${IDF_TARGET}" STREQUAL "esp32s2")
+if("${IDF_TARGET}" STREQUAL "esp32c3" OR "${IDF_TARGET}" STREQUAL "esp32c5" OR "${IDF_TARGET}" STREQUAL "esp32c6" OR "${IDF_TARGET}" STREQUAL "esp32s2")
     message(STATUS "Explicitly excluding M5GFX component for ${IDF_TARGET}")
     return()
 endif()


### PR DESCRIPTION
Excludes the c3 from importing M5GFX