### PR TITLE
Neopixel brightness setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Added 802.15.4 packet capture (only on C5, C6)
 - Alternate main menu layout (Grid)
 - Added glog - a lightweight logging helper
-- Added 'set/getneopixelbrightness' commands to set or get the max brightness of the neopixels
+- Added 'set/getneopixelbrightness' commands to set or get the max brightness of the neopixels - @tototo31
 
 - **PN532 NFC Capability**
   - **NTAG Support (Type 2)**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added 802.15.4 packet capture (only on C5, C6)
 - Alternate main menu layout (Grid)
 - Added glog - a lightweight logging helper
+- Added 'set/getneopixelbrightness' commands to set or get the max brightness of the neopixels
 
 - **PN532 NFC Capability**
   - **NTAG Support (Type 2)**

--- a/docs/wiki/Commands.md
+++ b/docs/wiki/Commands.md
@@ -220,6 +220,12 @@
 - <code>setrgbpins &lt;red&gt; &lt;green&gt; &lt;blue&gt;</code>  
   Change RGB LED pins
 
+- <code>setneopixelbrightness &lt;0-100&gt;</code>
+  Set the maximum neopixel brightness (percent). Example: `setneopixelbrightness 50`
+
+- <code>getneopixelbrightness</code>
+  Show the current saved neopixel max brightness (percent).
+
 - <code>sd_config</code>  
   Show current SD GPIO pin configuration
 

--- a/include/core/utils.h
+++ b/include/core/utils.h
@@ -25,6 +25,19 @@ void scale_grb_by_brightness(uint8_t *g, uint8_t *r, uint8_t *b, float brightnes
     *b = (uint8_t)(*b * brightness);
 }
 
+void scale_grb_by_neopixel_brightness(uint8_t *g, uint8_t *r, uint8_t *b, float base_brightness, uint8_t max_brightness_percent) {
+    // First apply the base brightness scaling
+    *g = (uint8_t)(*g * base_brightness);
+    *r = (uint8_t)(*r * base_brightness); 
+    *b = (uint8_t)(*b * base_brightness);
+    
+    // Then apply the neopixel max brightness setting (0-100%)
+    float neopixel_scale = max_brightness_percent / 100.0f;
+    *g = (uint8_t)(*g * neopixel_scale);
+    *r = (uint8_t)(*r * neopixel_scale);
+    *b = (uint8_t)(*b * neopixel_scale);
+}
+
 bool is_in_task_context(void);
 
 void url_decode(char *decoded, const char *encoded);

--- a/include/managers/settings_manager.h
+++ b/include/managers/settings_manager.h
@@ -104,6 +104,9 @@ typedef struct {
   // Navigation buttons setting
   bool nav_buttons_enabled; // Toggle for main menu navigation buttons
   uint8_t menu_layout; // Menu layout type (0=Carousel, 1=Grid, 2=Wii Cards)
+  
+  // Neopixel settings
+  uint8_t neopixel_max_brightness; // Max neopixel brightness (0-100)
 } FSettings;
 
 // Function declarations
@@ -248,6 +251,10 @@ bool settings_get_nav_buttons_enabled(const FSettings *settings);
 // Menu layout settings
 void settings_set_menu_layout(FSettings *settings, uint8_t layout);
 uint8_t settings_get_menu_layout(const FSettings *settings);
+
+// Neopixel brightness settings
+void settings_set_neopixel_max_brightness(FSettings *settings, uint8_t brightness);
+uint8_t settings_get_neopixel_max_brightness(const FSettings *settings);
 
 extern FSettings G_Settings;
 

--- a/main/core/commandline.c
+++ b/main/core/commandline.c
@@ -2092,6 +2092,8 @@ void handle_listportals(int argc, char **argv);
 void handle_evilportal(int argc, char **argv);
 void handle_wifi_disconnect(int argc, char **argv);
 void handle_set_rgb_mode_cmd(int argc, char **argv);
+void handle_set_neopixel_brightness_cmd(int argc, char **argv);
+void handle_get_neopixel_brightness_cmd(int argc, char **argv);
 
 void handle_comm_discovery(int argc, char **argv) {
     comm_state_t state = esp_comm_manager_get_state();
@@ -2437,6 +2439,8 @@ void register_commands() {
     register_command("blespam", handle_ble_spam_cmd);
 #endif
     register_command("setrgbmode", handle_set_rgb_mode_cmd);
+    register_command("setneopixelbrightness", handle_set_neopixel_brightness_cmd);
+    register_command("getneopixelbrightness", handle_get_neopixel_brightness_cmd);
     
     esp_comm_manager_set_command_callback(comm_command_callback, NULL);
     
@@ -2540,4 +2544,27 @@ void handle_set_rgb_mode_cmd(int argc, char **argv) {
     settings_set_rgb_mode(&G_Settings, mode);
     settings_save(&G_Settings);
     glog("RGB mode set to %s\n", argv[1]);
+}
+
+void handle_set_neopixel_brightness_cmd(int argc, char **argv) {
+    if (argc != 2) {
+        glog("Usage: setneopixelbrightness <0-100>\n");
+        glog("Example: setneopixelbrightness 50\n");
+        return;
+    }
+    
+    int brightness = atoi(argv[1]);
+    if (brightness < 0 || brightness > 100) {
+        glog("Invalid brightness value '%s'. Must be between 0-100\n", argv[1]);
+        return;
+    }
+    
+    settings_set_neopixel_max_brightness(&G_Settings, (uint8_t)brightness);
+    settings_save(&G_Settings);
+    glog("Neopixel max brightness set to %d%%\n", brightness);
+}
+
+void handle_get_neopixel_brightness_cmd(int argc, char **argv) {
+    uint8_t brightness = settings_get_neopixel_max_brightness(&G_Settings);
+    glog("Current neopixel max brightness: %d%%\n", brightness);
 }

--- a/main/core/commandline.c
+++ b/main/core/commandline.c
@@ -1217,7 +1217,9 @@ void handle_help(int argc, char **argv) {
         glog("\nLED & RGB Commands:\n\n");
         printf("rgbmode\n    Control LED effects (rainbow, police, strobe, off)\n    Usage: rgbmode <rainbow|police|strobe|off|color>\n\n");
         printf("setrgbpins\n    Change RGB LED pins\n    Usage: setrgbpins <red> <green> <blue>\n           (use same value for all pins for single-pin LED strips)\n\n");
-        TERMINAL_VIEW_ADD_TEXT("rgbmode, setrgbpins\n");
+        printf("setneopixelbrightness\n    Set maximum neopixel brightness (percent)\n    Usage: setneopixelbrightness <0-100>\n\n");
+        printf("getneopixelbrightness\n    Show current neopixel max brightness (percent)\n    Usage: getneopixelbrightness\n\n");
+        TERMINAL_VIEW_ADD_TEXT("rgbmode, setrgbpins, setneopixelbrightness, getneopixelbrightness\n");
         return;
     }
 

--- a/main/managers/ap_manager.c
+++ b/main/managers/ap_manager.c
@@ -1063,6 +1063,11 @@ static esp_err_t api_settings_handler(httpd_req_t *req) {
         settings_set_rgb_speed(settings, rgb_speed->valueint);
     }
 
+    cJSON *neopixel_brightness = cJSON_GetObjectItem(root, "neopixel_brightness");
+    if (neopixel_brightness) {
+        settings_set_neopixel_max_brightness(settings, (uint8_t)neopixel_brightness->valueint);
+    }
+
     cJSON *channel_delay = cJSON_GetObjectItem(root, "channel_delay");
     if (channel_delay) {
         settings_set_channel_delay(settings, (float)channel_delay->valuedouble);

--- a/main/managers/rgb_manager.c
+++ b/main/managers/rgb_manager.c
@@ -7,6 +7,7 @@
 #include "freertos/task.h"
 #include "freertos/semphr.h"
 #include "math.h"
+#include "core/utils.h"
 
 static const char *TAG = "RGBManager";
 static SemaphoreHandle_t rgb_mutex = NULL;
@@ -305,7 +306,7 @@ void set_led_column(RGBManager_t *rgb_manager, size_t column, uint8_t height) {
 
   uint8_t r = 255, g = 1, b = 1;
 
-  scale_grb_by_brightness(&g, &r, &b, 0.1);
+  scale_grb_by_neopixel_brightness(&g, &r, &b, 0.1, settings_get_neopixel_max_brightness(&G_Settings));
 
   // Light up the required number of LEDs with the selected primary color
   for (int row = 0; row < height; ++row) {
@@ -510,7 +511,7 @@ esp_err_t rgb_manager_set_color(RGBManager_t *rgb_manager, int led_idx,
             pulse_once(rgb_manager, red, green, blue);
         } else {
             uint8_t r = red, g = green, b = blue;
-            scale_grb_by_brightness(&g, &r, &b, 0.3); // Scale brightness for RMT
+            scale_grb_by_neopixel_brightness(&g, &r, &b, 0.3, settings_get_neopixel_max_brightness(&G_Settings)); // Scale brightness for RMT with neopixel setting
 
             esp_err_t ret = ESP_OK;
             if (xSemaphoreTakeRecursive(rgb_mutex, portMAX_DELAY) == pdTRUE) {
@@ -590,7 +591,7 @@ void rgb_manager_rainbow_effect_matrix(RGBManager_t *rgb_manager,
       blue = (uint8_t)(fmin(rgb_color.b * 255, 120));
 
       clamp_rgb(&red, &green, &blue);
-      scale_grb_by_brightness(&green, &red, &blue, 0.3);
+      scale_grb_by_neopixel_brightness(&green, &red, &blue, 0.3, settings_get_neopixel_max_brightness(&G_Settings));
 
       led_strip_set_pixel(rgb_manager->strip, i, red, green, blue);
       hue = fmod(hue + 0.5, 360.0);

--- a/main/managers/settings_manager.c
+++ b/main/managers/settings_manager.c
@@ -58,6 +58,7 @@ static const char *NVS_ZEBRA_MENUS_KEY = "zebra_menus";
 static const char *NVS_MAX_SCREEN_BRIGHTNESS_KEY = "max_bright";
 static const char *NVS_NAV_BUTTONS_KEY = "nav_buttons";
 static const char *NVS_MENU_LAYOUT_KEY = "menu_layout";
+static const char *NVS_NEOPIXEL_MAX_BRIGHTNESS_KEY = "neopixel_bright";
 
 
 static const char *TAG = "SettingsManager";
@@ -152,6 +153,7 @@ void settings_set_defaults(FSettings *settings) {
   settings->infrared_easy_mode = false; // Default to disabled
   settings->nav_buttons_enabled = true; // Default to enabled
   settings->menu_layout = 0; // Default to carousel layout
+  settings->neopixel_max_brightness = 100; // Default to 100% brightness
 }
 
 void settings_load(FSettings *settings) {
@@ -457,6 +459,14 @@ void settings_load(FSettings *settings) {
     settings->menu_layout = value_u8;
   } else {
     settings->menu_layout = 0; // Default to carousel layout if not found
+  }
+
+  // Load Neopixel Max Brightness
+  err = nvs_get_u8(nvsHandle, NVS_NEOPIXEL_MAX_BRIGHTNESS_KEY, &value_u8);
+  if (err == ESP_OK) {
+    settings->neopixel_max_brightness = value_u8;
+  } else {
+    settings->neopixel_max_brightness = 100; // Default to 100% if not found
   }
 }
 
@@ -767,6 +777,9 @@ void settings_save(const FSettings *settings) {
 
   err = nvs_set_u8(nvsHandle, NVS_MENU_LAYOUT_KEY, settings->menu_layout);
   if (err != ESP_OK) ESP_LOGE(S_TAG, "Failed to save menu_layout: %s", esp_err_to_name(err));
+
+  err = nvs_set_u8(nvsHandle, NVS_NEOPIXEL_MAX_BRIGHTNESS_KEY, settings->neopixel_max_brightness);
+  if (err != ESP_OK) ESP_LOGE(S_TAG, "Failed to save neopixel_max_brightness: %s", esp_err_to_name(err));
 
   err = nvs_commit(nvsHandle);
   if (err != ESP_OK) ESP_LOGE(S_TAG, "Failed to commit settings: %s", esp_err_to_name(err));
@@ -1203,4 +1216,14 @@ void settings_set_menu_layout(FSettings *settings, uint8_t layout) {
 
 uint8_t settings_get_menu_layout(const FSettings *settings) {
     return settings->menu_layout;
+}
+
+// Neopixel brightness settings
+void settings_set_neopixel_max_brightness(FSettings *settings, uint8_t brightness) {
+    if (brightness > 100) brightness = 100;
+    settings->neopixel_max_brightness = brightness;
+}
+
+uint8_t settings_get_neopixel_max_brightness(const FSettings *settings) {
+    return settings->neopixel_max_brightness;
 }

--- a/main/managers/views/options_screen.c
+++ b/main/managers/views/options_screen.c
@@ -34,7 +34,7 @@ static const char **evil_portal_options = NULL;
 
 static const char *TAG = "optionsScreen";
 
-static const char *settings_categories[] = {"Display", "Config", NULL};
+static const char *settings_categories[] = {"Display", "Hardware config", NULL};
 
 typedef enum {
     SETTINGS_CATEGORY_DISPLAY,
@@ -48,16 +48,19 @@ static int current_settings_category = -1;
 // Each sub-array lists the indices of settings_items[] that belong to a category.
 // The last element in each sub-array must be -1 to mark the end.
 //
-// Category 0: "Display" (indices: 1, 2, 5, 3, 4, 9)
-// Category 1: "Config"  (indices: 0, 6, 7, 8)
+// Category 0: "Display" (indices: 1, 2, 5, 3, 4, 9, 11, 12) when CONFIG_LV_DISP_BACKLIGHT_PWM enabled
+// Category 0: "Display" (indices: 1, 2, 5, 3, 4, 10, 11) when CONFIG_LV_DISP_BACKLIGHT_PWM disabled
+// Category 1: "Hardware config"  (indices: 0, 6, 7, 8, 10) when CONFIG_LV_DISP_BACKLIGHT_PWM enabled
+// Category 1: "Hardware config"  (indices: 0, 6, 7, 8, 9) when CONFIG_LV_DISP_BACKLIGHT_PWM disabled
 // Example: settings_category_indices[0] lists settings for "Display" category.
 static int settings_category_indices[][10] = {
     #ifdef CONFIG_LV_DISP_BACKLIGHT_PWM
-        {1, 2, 5, 3, 4, 9, 10, 11, 12, -1}, // Display: Display Timeout, Menu Theme, Invert Colors, Third Control, Terminal Color, Max Brightness, Zebra Menus, Navigation Buttons, Menu Layout
+        {1, 2, 5, 3, 4, 9, 11, 12, -1}, // Display: Display Timeout, Menu Theme, Invert Colors, Third Control, Terminal Color, Max Brightness, Zebra Menus, Navigation Buttons, Menu Layout
+        {0, 6, 7, 8, 10, -1}, // Hardware config: RGB Mode, Web Auth, AP Enabled, Power Saving Mode, Neopixel Brightness
     #else
-        {1, 2, 5, 3, 4, 9, 10, 11, -1},     // Display: Display Timeout, Menu Theme, Invert Colors, Third Control, Terminal Color, Zebra Menus, Navigation Buttons, Menu Layout
+        {1, 2, 5, 3, 4, 10, 11, -1},     // Display: Display Timeout, Menu Theme, Invert Colors, Third Control, Terminal Color, Zebra Menus, Navigation Buttons, Menu Layout
+        {0, 6, 7, 8, 9, -1}, // Hardware config: RGB Mode, Web Auth, AP Enabled, Power Saving Mode, Neopixel Brightness
     #endif
-        {0, 6, 7, 8, -1}, // Config: RGB Mode, Web Auth, AP Enabled, Power Saving Mode
 };
 
 typedef enum {

--- a/main/managers/views/options_screen.c
+++ b/main/managers/views/options_screen.c
@@ -148,16 +148,15 @@ enum {
     SETTING_AP_ENABLED,
     SETTING_POWER_SAVE,
     SETTING_MAX_BRIGHTNESS,
+    SETTING_NEOPIXEL_BRIGHTNESS,
     SETTING_ZEBRA_MENUS,
     SETTING_NAV_BUTTONS,
     SETTING_MENU_LAYOUT
 };
 
-#ifdef CONFIG_LV_DISP_BACKLIGHT_PWM
 static const char *brightness_options[] = {
     "10%", "20%", "30%", "40%", "50%", "60%", "70%", "80%", "90%", "100%"
 };
-#endif
 
 static SettingsItem settings_items[] = {
     {"RGB Mode", SETTING_RGB_MODE, rgb_mode_options, 3, 0},
@@ -172,6 +171,7 @@ static SettingsItem settings_items[] = {
     #ifdef CONFIG_LV_DISP_BACKLIGHT_PWM
     {"Max Brightness", SETTING_MAX_BRIGHTNESS, brightness_options, 10, 9}, // default 100%
     #endif
+    {"Neopixel Brightness", SETTING_NEOPIXEL_BRIGHTNESS, brightness_options, 10, 9}, // default 100%
     {"Zebra Menus", SETTING_ZEBRA_MENUS, bool_options, 2, 0},
     {"Navigation Buttons", SETTING_NAV_BUTTONS, bool_options, 2, 1},
     {"Menu Layout", SETTING_MENU_LAYOUT, menu_layout_options, 2, 0}
@@ -554,6 +554,9 @@ static void load_current_settings_values(void) {
             case SETTING_MAX_BRIGHTNESS:
                 settings_items[i].current_value = (settings_get_max_screen_brightness(&G_Settings) / 10) - 1;
                 break;
+            case SETTING_NEOPIXEL_BRIGHTNESS:
+                settings_items[i].current_value = (settings_get_neopixel_max_brightness(&G_Settings) / 10) - 1;
+                break;
             default:
                 settings_items[i].current_value = 0;
                 break;
@@ -622,6 +625,9 @@ static void apply_setting_change(int setting_index, int new_value) {
             set_backlight_brightness(100); // set to 100 since brightness becomes scaled by the max
             break;
         #endif
+        case SETTING_NEOPIXEL_BRIGHTNESS:
+            settings_set_neopixel_max_brightness(&G_Settings, (uint8_t)((new_value + 1) * 10));
+            break;
     }
     settings_save(&G_Settings);
 }

--- a/main/managers/views/options_screen.c
+++ b/main/managers/views/options_screen.c
@@ -55,10 +55,10 @@ static int current_settings_category = -1;
 // Example: settings_category_indices[0] lists settings for "Display" category.
 static int settings_category_indices[][10] = {
     #ifdef CONFIG_LV_DISP_BACKLIGHT_PWM
-        {1, 2, 5, 3, 4, 9, 11, 12, -1}, // Display: Display Timeout, Menu Theme, Invert Colors, Third Control, Terminal Color, Max Brightness, Zebra Menus, Navigation Buttons, Menu Layout
+        {1, 2, 5, 3, 4, 9, 11, 12, 13, -1}, // Display: Display Timeout, Menu Theme, Invert Colors, Third Control, Terminal Color, Max Brightness, Zebra Menus, Navigation Buttons, Menu Layout
         {0, 6, 7, 8, 10, -1}, // Hardware config: RGB Mode, Web Auth, AP Enabled, Power Saving Mode, Neopixel Brightness
     #else
-        {1, 2, 5, 3, 4, 10, 11, -1},     // Display: Display Timeout, Menu Theme, Invert Colors, Third Control, Terminal Color, Zebra Menus, Navigation Buttons, Menu Layout
+        {1, 2, 5, 3, 4, 10, 11, 12, -1},     // Display: Display Timeout, Menu Theme, Invert Colors, Third Control, Terminal Color, Zebra Menus, Navigation Buttons, Menu Layout
         {0, 6, 7, 8, 9, -1}, // Hardware config: RGB Mode, Web Auth, AP Enabled, Power Saving Mode, Neopixel Brightness
     #endif
 };


### PR DESCRIPTION
add the ability to let the user control the brightness of neopixels

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a persisted neopixel max-brightness (0–100%) setting, exposed via CLI and Settings UI, applied in RGB output scaling, and added to API/docs.
> 
> - **RGB/Rendering**:
>   - Add `scale_grb_by_neopixel_brightness(...)` in `core/utils.h` and apply across `rgb_manager.c` (visualizer, set_color, rainbow) to cap LED output by saved max brightness.
> - **Settings/Persistence**:
>   - Extend `FSettings` with `neopixel_max_brightness` (+ NVS key `neopixel_bright`), defaults to 100; load/save and getters/setters in `settings_manager.[ch]`.
>   - WebUI API (`ap_manager.c`): accept `neopixel_brightness` in settings JSON.
> - **CLI**:
>   - Add commands: `setneopixelbrightness <0-100>`, `getneopixelbrightness`; update `help led` output and register handlers.
> - **UI**:
>   - Settings screen: add "Neopixel Brightness" selectable option; reorganize categories label to "Hardware config" and adjust indices.
> - **Docs/Changelog**:
>   - Document new commands in `docs/wiki/Commands.md`.
>   - Update `CHANGELOG.md` with neopixel brightness commands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf6813e83a3943e3b79b08f3af49acec870d1720. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->