### PR TITLE
Add git commit hash retrieval and logging at build time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ if("${IDF_TARGET}" STREQUAL "esp32s2")
     add_compile_definitions(CONFIG_IDF_TARGET_ESP32S2)
 endif()
 
-# Get git commit hash at build time
+# Get git commit hash and branch at build time
 find_package(Git QUIET)
 if(GIT_FOUND)
     execute_process(
@@ -33,12 +33,25 @@ if(GIT_FOUND)
     if(NOT GIT_COMMIT_HASH)
         set(GIT_COMMIT_HASH "unknown")
     endif()
+    
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_BRANCH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+    )
+    if(NOT GIT_BRANCH)
+        set(GIT_BRANCH "unknown")
+    endif()
 else()
     set(GIT_COMMIT_HASH "unknown")
+    set(GIT_BRANCH "unknown")
 endif()
 
-# Add git commit hash as compile definition
+# Add git commit hash and branch as compile definitions
 add_compile_definitions(GIT_COMMIT_HASH="${GIT_COMMIT_HASH}")
+add_compile_definitions(GIT_BRANCH="${GIT_BRANCH}")
 
 # Include project settings
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,26 @@ if("${IDF_TARGET}" STREQUAL "esp32s2")
     add_compile_definitions(CONFIG_IDF_TARGET_ESP32S2)
 endif()
 
+# Get git commit hash at build time
+find_package(Git QUIET)
+if(GIT_FOUND)
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_COMMIT_HASH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+    )
+    if(NOT GIT_COMMIT_HASH)
+        set(GIT_COMMIT_HASH "unknown")
+    endif()
+else()
+    set(GIT_COMMIT_HASH "unknown")
+endif()
+
+# Add git commit hash as compile definition
+add_compile_definitions(GIT_COMMIT_HASH="${GIT_COMMIT_HASH}")
+
 # Include project settings
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(Ghost_ESP_IDF)

--- a/include/core/ghostesp_version.h
+++ b/include/core/ghostesp_version.h
@@ -5,4 +5,6 @@
 #define GHOSTESP_FLAVOR "Revival"
 #define GHOSTESP_VERSION "v1.9.2"
 
+// GIT_COMMIT_HASH is defined as a compile definition in CMakeLists.txt
+
 #endif

--- a/include/core/ghostesp_version.h
+++ b/include/core/ghostesp_version.h
@@ -5,6 +5,6 @@
 #define GHOSTESP_FLAVOR "Revival"
 #define GHOSTESP_VERSION "v1.9.2"
 
-// GIT_COMMIT_HASH is defined as a compile definition in CMakeLists.txt
+// GIT_COMMIT_HASH and GIT_BRANCH are defined as compile definitions in CMakeLists.txt
 
 #endif

--- a/main/main.c
+++ b/main/main.c
@@ -1,6 +1,7 @@
 #include "core/commandline.h"
 #include "core/serial_manager.h"
 #include "core/system_manager.h"
+#include "core/ghostesp_version.h"
 #include "managers/ap_manager.h"
 #include "managers/display_manager.h"
 #include "managers/rgb_manager.h"
@@ -270,6 +271,9 @@ void app_main(void) {
 
     ESP_LOGI(TAG, "Build config used: %s", CONFIG_BUILD_CONFIG_TEMPLATE);
     printf("Build Name: %s\n", CONFIG_BUILD_CONFIG_TEMPLATE);
+    
+    ESP_LOGI(TAG, "Git commit hash: %s", GIT_COMMIT_HASH);
+    printf("Git commit hash: %s\n", GIT_COMMIT_HASH);
 
     size_t free_heap = heap_caps_get_free_size(MALLOC_CAP_8BIT);
     size_t total_heap = heap_caps_get_total_size(MALLOC_CAP_8BIT);

--- a/main/main.c
+++ b/main/main.c
@@ -272,8 +272,8 @@ void app_main(void) {
     ESP_LOGI(TAG, "Build config used: %s", CONFIG_BUILD_CONFIG_TEMPLATE);
     printf("Build Name: %s\n", CONFIG_BUILD_CONFIG_TEMPLATE);
     
-    ESP_LOGI(TAG, "Git commit hash: %s", GIT_COMMIT_HASH);
-    printf("Git commit hash: %s\n", GIT_COMMIT_HASH);
+    ESP_LOGI(TAG, "Git branch: %s, commit: %s", GIT_BRANCH, GIT_COMMIT_HASH);
+    printf("Git branch: %s, commit: %s\n", GIT_BRANCH, GIT_COMMIT_HASH);
 
     size_t free_heap = heap_caps_get_free_size(MALLOC_CAP_8BIT);
     size_t total_heap = heap_caps_get_total_size(MALLOC_CAP_8BIT);


### PR DESCRIPTION
- Updated CMakeLists.txt to include git commit hash as a compile definition.
- Modified main.c to log the git commit hash during application startup.
- Added a comment in ghostesp_version.h to document the new compile definition.

# What's new (Author - fill this out)
- embeds git commit hash info right after build info

# Verification (Author - fill this out)
- I have tested Primary device(s) (list exact HW + config):  Poltergiest
- I have tested potentially affected devices (and/or list potential affected devices not available to you):  technically every build would be affected 
- I have wrapped device specific code with `#ifdef CONFIG_...` or similar: [ ] Yes / [ x] N/A
- I have updated Hugo Docs with any new or changed info for end users: [ ] Yes / [ x] N/A

## Linked Issues
- Closes #237

## Checklist (Reviewer - don't fill this out)
- [ ] Code builds, flashes, and feature verified with no functional issues on listed device(s)
- [ ] Changes reviewed for unintended impact on other devices/targets

