### PR TITLE
build fix

### DIFF
--- a/main/managers/wifi_manager.c
+++ b/main/managers/wifi_manager.c
@@ -471,14 +471,16 @@ static void wifi_ap_diag_event_handler(void *arg, esp_event_base_t event_base, i
             case WIFI_EVENT_AP_STACONNECTED: {
                 const wifi_event_ap_staconnected_t *e = (const wifi_event_ap_staconnected_t *)event_data;
                 if (e) {
-                    ESP_LOGI(TAG, "ap: sta connected: " MACSTR " aid=%d", MAC2STR(e->mac), (int)e->aid);
+                    ESP_LOGI(TAG, "ap: sta connected: %02x:%02x:%02x:%02x:%02x:%02x aid=%d",
+                             e->mac[0], e->mac[1], e->mac[2], e->mac[3], e->mac[4], e->mac[5], (int)e->aid);
                 }
                 break;
             }
             case WIFI_EVENT_AP_STADISCONNECTED: {
                 const wifi_event_ap_stadisconnected_t *e = (const wifi_event_ap_stadisconnected_t *)event_data;
                 if (e) {
-                    ESP_LOGI(TAG, "ap: sta disconnected: " MACSTR " aid=%d reason=%d", MAC2STR(e->mac),
+                    ESP_LOGI(TAG, "ap: sta disconnected: %02x:%02x:%02x:%02x:%02x:%02x aid=%d reason=%d",
+                             e->mac[0], e->mac[1], e->mac[2], e->mac[3], e->mac[4], e->mac[5],
                              (int)e->aid, (int)e->reason);
                 }
                 break;


### PR DESCRIPTION
# What's new (Author - fill this out)
- 

# Changed
-

# Removed
-

# Verification (Author - fill this out)
- I have tested Primary device(s) (list exact HW + config): 
- I have tested potentially affected devices (and/or list potential affected devices not available to you):  
- I have wrapped device specific code with `#ifdef CONFIG_...` or similar: [ ] Yes / [ ] N/A
- I have updated Hugo Docs with any new or changed info for end users: [ ] Yes / [ ] N/A

## Linked Issues
- Closes #

## Checklist (Reviewer - don't fill this out)
- [ ] Code builds, flashes, and feature verified with no functional issues on listed device(s)
- [ ] Changes reviewed for unintended impact on other devices/targets


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to AP event log formatting and should not affect Wi‑Fi behavior beyond message content/build compatibility.
> 
> **Overview**
> Updates `wifi_ap_diag_event_handler` logging in `wifi_manager.c` to print station MAC addresses via explicit `%02x` formatting instead of `MACSTR`/`MAC2STR` for AP connect/disconnect events, improving build compatibility while keeping the same diagnostics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e2c1a332169a5950bd96ab86f09f35b59db45df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->